### PR TITLE
fix(Forgot): correct className for main container div

### DIFF
--- a/src/modules/Password/components/Forgot.js
+++ b/src/modules/Password/components/Forgot.js
@@ -7,7 +7,7 @@ const Body = () => {
   };
 
   return (
-    <div className={styles.contentnpm}>
+    <div className={styles.content}>
       <h1>Forgot your password?</h1>
       <p className="h1">No problem!</p>
 


### PR DESCRIPTION
After the large refactor/lint the div inside Forgot.js's className changed. It was no longer receiving the styles from Password.scss