### PR TITLE
fix(ProfileForm): correct positioning of form elements

### DIFF
--- a/src/modules/Profile/components/ProfileForm.js
+++ b/src/modules/Profile/components/ProfileForm.js
@@ -42,12 +42,12 @@ export default class ProfileForm extends Component {
       field: 'username'
     },
     {
-      label: 'Email',
+      label: 'E-mail',
       type: 'email',
       field: 'email'
     },
     {
-      label: 'Confirm Email',
+      label: 'Confirm E-mail',
       type: 'email',
       field: 'confirmEmail'
     }
@@ -101,13 +101,13 @@ export default class ProfileForm extends Component {
           <p>Injury <span>(optional)</span></p>
 
           <div className={styles.combat}>
-            <label htmlFor='combat'>Combat</label>
             <input type='checkbox' name='combat' />
+            <label htmlFor='combat'>Combat</label>
           </div>
 
           <div className={styles.noncombat}>
-            <label htmlFor='noncombat'>Non-combat</label>
             <input type='checkbox' name='noncombat' />
+            <label htmlFor='noncombat'>Non-combat</label>
           </div>
         </div>
         {error && <p className="text-danger"><strong>{error}</strong></p>}

--- a/src/modules/Profile/components/ProfileForm.scss
+++ b/src/modules/Profile/components/ProfileForm.scss
@@ -5,6 +5,10 @@
 	flex-direction: column;
 	justify-content: center;
 	width: 90%;
+	
+	label {
+		font-size: 1.2em;
+	}
 
 	input {
 		box-shadow: $box-shadow;
@@ -37,24 +41,26 @@
 	.combat {
 		width: 50%;
 		float: left;
-		> label {
-			display: block;
-		}
 		> input {
 			box-shadow: none;
-			margin: auto;
+			float: left;
+			margin: .3em 1em auto 3.5em;
+		}
+		> label {
+			float: left;
 		}
 	}
 
 	.noncombat {
 		width: 50%;
 		float: right;
-		> label {
-			display: block;
-		}
 		> input {
 			box-shadow: none;
-			margin: auto;
+			float: left;
+			margin: .3em 1em auto 1.25em;
+		}
+		> label {
+			float: left;
 		}
 	}
 


### PR DESCRIPTION
The labels for the `checkboxes` in the `injury` section were in the wrong position. This should correct that.