### PR TITLE
docs(github): add directory with templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,24 @@
+Thank you for your interest in Project Refit!
+
+To avoid duplicates, please search the [issue track](https://github.com/prjctrft/mantenuto/issues) before creating an issue.
+
+## Expected Behavior
+Reporting a bug? Tell us what should happen.
+Suggesting a change? Tell us how it should work.
+
+## Current Behavior
+Reporting a bug? Tell us what currently happens.
+Suggesting a change? Explain the current behavior you want to change.
+
+## Possible Solution
+If you can, suggest a fix or cause for the bug,
+or ideas about how to implement the addition or change.
+
+## Context 
+What were you trying to do when this issue affected you? 
+This context will help us find the best solution for all users.
+
+## Your Environment
+* Browser name and version
+* Operating system and version
+* Device

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+Thank you for contributing to Project Refit!
+
+To avoid duplicates, please search existing [pull requests](https://github.com/prjctrft/mantenuto/pulls) before creating one.
+
+Please read and follow the [Contributing Guidelines](https://github.com/prjctrft/mantenuto/blob/master/CONTRIBUTING.md) to create your pull request.
+
+## Summary
+Does this PR fix a bug? Add a feature?
+
+## Why
+What problem does this PR solve?
+If adding a feature, tell us why the feature is needed.
+
+## Tests
+
+## Code Style
+
+## Issue Closed
+Does this PR close an issue? Great! Tell us which one.
+Fixes #
+
+


### PR DESCRIPTION
@hdngr I left the "Tests" and "Code Style" sections of the Pull Request Template blank, because I was not sure of the details there. Hopefully this gets us started. 

The templates are derived from https://github.com/stevemao/github-issue-templates/tree/master/no-duplicates

Fixes #117 