### PR TITLE
refactor(Listen): Use RefitButton for Preferences component

### DIFF
--- a/src/modules/Listen/components/Connecting.js
+++ b/src/modules/Listen/components/Connecting.js
@@ -10,7 +10,7 @@ const Connecting = (props) => {
     <Wrapper>
       <div className='container'>
         <div className='row'>
-          <div className='col-xs-12 text-center'>
+          <div className='col-12 text-center'>
             {props.onlineTalkers ? <h2>There are currently {props.onlineTalkers} vets online wanting to chat.</h2> : null}
             <p className='lead'>Finding someone that needs your ears now!</p>
             <ClipLoader

--- a/src/modules/Listen/components/Preferences.js
+++ b/src/modules/Listen/components/Preferences.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types'; 
 
-import CircleButton from 'components/CircleButton';
+import RefitButton from 'components/RefitButton';
 
 import Wrapper from './Wrapper';
 
@@ -11,16 +11,16 @@ const Preferences  = (props) => {
     <Wrapper>
       <div className={styles.btns}>
         <div className='row'>
-          <div className={`col-sm-5 ${styles.noWrap}`}>
+          <div className={`col-sm-5 text-center ${styles.noWrap}`}>
             <h3>Can you listen anytime?</h3>
-            <CircleButton className={`${styles.marginAuto} ${styles.anytime}`} onClick={props.handleAnytime} content='Anytime' />
+            <RefitButton className={`${styles.marginAuto} ${styles.anytime}`} onClick={props.handleAnytime} content='Anytime' />
           </div>
           <div className='col-sm-2 text-center'>
             <h3>Or</h3>
           </div>
-          <div className={`col-sm-5 ${styles.noWrap}`}>
+          <div className={`col-sm-5 text-center ${styles.noWrap}`}>
             <h3>Can you only listen now?</h3>
-            <CircleButton className={`${styles.marginAuto} ${styles.now}`} onClick={props.handleNow} content='Now' />
+            <RefitButton className={`${styles.marginAuto} ${styles.now}`} onClick={props.handleNow} content='Now' />
           </div>
         </div>
       </div>

--- a/src/modules/Listen/components/Preferences.scss
+++ b/src/modules/Listen/components/Preferences.scss
@@ -11,7 +11,6 @@
 //   margin-bottom: 1rem;
 // };
 
-
 .noWrap {
   white-space: nowrap;
 }


### PR DESCRIPTION
## Summary
Uses RefitButton instead of CircleButton in Listen/components/Preferences.js

## Why
RefitButton renders square button on mobile screens


